### PR TITLE
Pretty timestamp by omitting decimal

### DIFF
--- a/public/index.jsx
+++ b/public/index.jsx
@@ -91,7 +91,7 @@ async function tsRenderer({ slot, payload: { arguments: args } }) {
 async function insertMediaTsRenderer() {
   const input = parent.document.activeElement
   const media = findMediaElement(input)
-  const currentTime = media?.currentTime ?? 0
+  const currentTime = Math.floor(media?.currentTime ?? 0)
   await logseq.Editor.insertAtEditingCursor(
     `{{renderer :media-timestamp, ${currentTime}}}`,
   )


### PR DESCRIPTION
First, thanks for making this amazing plugin. I listen to many podcasts and I was just considering to create such a plugin myself. Luckily I found your plugin. It works like charm, there is only little thing I've noticed. The timestamp is provided as decimal which makes the timestamp hard to read (in my opinion). The `currentTime` property returns the current time in seconds and I think it is save to omit the decimal (ms). 

### Before (current version)
<img width="274" alt="image" src="https://user-images.githubusercontent.com/1393946/163875497-77457d5b-93ea-4fe5-9e81-949b75448d07.png">


### After 
<img width="243" alt="image" src="https://user-images.githubusercontent.com/1393946/163875553-296fd6a7-68f3-4a5f-938b-e7f6760fa99c.png">

